### PR TITLE
PowerBI API 5.3 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm i -g powerbi-visuals-tools
 
 Registration of a Power BI certificate for localhost:
 ```bash
-pbiviz --install-cert
+pbiviz install-cert
 ```
 
 Starting the custom Power BI development server:
@@ -30,7 +30,7 @@ Starting the custom Power BI development server:
 ```
 
 If the certificate is still giving problems with an error like _"net::ERR_CERT_COMMON_NAME_INVALID"_, it's because the Chrome browser blocks the address https://localhost:8080 because of a non-valid certificate.
-Please open the following link in separate browser tab: https://localhost:8080/assets/status. Chrome will show the warning message, click `advanced > proceed` to unsafe version. After that, Chrome will work with the development visual correctly.
+Please open the following link in separate browser tab: https://localhost:8080/assets/status. Chrome will show a warning message, type in the address bar `chrome://flags/#allow-insecure-localhost` to allow using localhost over https. After that, Chrome will work with the development visual correctly.
 
 You can use any browser to enjoy Power BI dashboards, but Chromium browsers like Edge and Chrome are aptest for debugging custom visuals.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "powerbi-visuals-api": "~5.1.0",
         "powerbi-visuals-utils-dataviewutils": "^6.0.0",
         "powerbi-visuals-utils-formattingmodel": "5.0.0",
-        "yfiles": "./yFiles/yfiles-25.0.3+dev.tgz"
+        "yfiles": "./yFiles/yfiles-26.0.3+dev.tgz"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.55.0",
@@ -1903,8 +1903,8 @@
       "license": "ISC"
     },
     "node_modules/yfiles": {
-      "version": "25.0.3+dev",
-      "resolved": "file:yFiles/yfiles-25.0.3+dev.tgz",
+      "version": "26.0.3+dev",
+      "resolved": "file:yFiles/yfiles-26.0.3+dev.tgz",
       "integrity": "sha512-PisR+YPEjs3IYcR/3UMtPbO0dTY5VrGoXE14zoB1vaJkbI+Zfjn2+mSrfx5kEjFiUAHimEYIe6lkVT3XqwQpqg=="
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yfiles-power-bi-integration-basic",
   "description": "Basic integration of yFiles for HTML in Power BI",
   "author": "yWorks GmbH <yfileshtml@yworks.com>",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "MIT",
   "scripts": {
@@ -12,10 +12,10 @@
     "lint": "npx eslint"
   },
   "dependencies": {
-    "powerbi-visuals-api": "~5.1.0",
+    "powerbi-visuals-api": "~5.3.0",
     "powerbi-visuals-utils-dataviewutils": "^6.0.0",
     "powerbi-visuals-utils-formattingmodel": "5.0.0",
-    "yfiles": "./yFiles/yfiles-25.0.3+dev.tgz"
+    "yfiles": "./yFiles/yfiles-26.0.3+dev.tgz"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.55.0",

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -4,17 +4,18 @@
     "displayName": "basic",
     "guid": "basic95B03181D2434E0FB4CAFD9B2F7B205F",
     "visualClassName": "Visual",
-    "version": "1.0.0",
+    "version": "1.0.0.0",
     "description": "",
     "supportUrl": "",
     "gitHubUrl": ""
   },
-  "apiVersion": "5.1.0",
+  "apiVersion": "5.3.0",
   "author": { "name": "", "email": "" },
   "assets": { "icon": "assets/icon.png" },
   "externalJS": null,
   "style": "style/visual.less",
   "capabilities": "capabilities.json",
   "dependencies": null,
-  "stringResources": []
+  "stringResources": [],
+  "version": "1.0.0.0"
 }


### PR DESCRIPTION
Various breaking changes in PowerBI:

- `chrome://flags/#allow-insecure-localhost` is now necessary to fix the `Continue to localhost (unsafe)` issue with localhost
- `pbiviz --install-cert` is now `pbiviz install-cert`
- pbiviz version `visual.version` is now four numbers, `1.0.0.0` instead of `1.0.0`

In addition:

- updated yFiles to version v2.6 (previously v2.5). 
- update the PowerBI API version to v5.3
- update the README accordingly

The update to v3 of yFiles will have to wait a bit until the dust has settled.
